### PR TITLE
Fix invalid player ref

### DIFF
--- a/interactions/interactionManager.gd
+++ b/interactions/interactionManager.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 #referencia a los nodos plauer y label
-@onready var Player = get_tree().get_first_node_in_group("player")
+var Player # El player se autoregistra aqui. Se puede definir un setter si se quieren hacer chequeos extra
 @onready var label = $Label
 
 
@@ -22,7 +22,8 @@ func unregister_area(area : interactionArea):
 
 #esta funcion controla si hay areas y muestra el label correspondiente
 func _process(_delta):
-	if active_areas.size() > 0 && Player.can_interact: #si la lista es mayor a 0
+	# Agrege el chequeo && Player ya que process si o si va a empezar a llamarse antes que el player este registrado
+	if active_areas.size() > 0 && Player && Player.can_interact: #si la lista es mayor a 0
 		active_areas.sort_custom(_sort_by_distance_to_player)# devuelve el area mas cercana al player con sort custom
 		label.text = base_text + active_areas[0].action_name #asigna el nombre correcto al label
 		label.global_position = active_areas[0].global_position # ubica el label en pantalla encima del objeto a interactuar 

--- a/scripts/player/Player.gd
+++ b/scripts/player/Player.gd
@@ -30,6 +30,10 @@ var prev_state = null
 
 #esta funcion recorre todos los estados de STATES, los almacena y hace una referencia a la variable Player del script "state"
 func _ready():
+	# registramos el player en el InteractionManager. Esto se podria hacer en _init() o _enter_tree()
+	# pero en ready es cuando ya todos los subnodos del player estan listos y accesibles
+	InteractionManager.Player = self
+
 	for state in STATES.get_children():
 		state.STATES = STATES
 		state.Player = self


### PR DESCRIPTION
- Como el interaction manager es un singleton, el player simplemente se autoregsitra
- Como el interactionmanager trata de acceder al player en process, antes de que este listo, se agrega un && Player antes de Player.can_interact para chequear que la referencia no sea nula